### PR TITLE
Copy dylibs to the application bundle instead of symlinks.

### DIFF
--- a/basilisk/app/Makefile.in
+++ b/basilisk/app/Makefile.in
@@ -83,6 +83,9 @@ tools repackage:: $(DIST)/bin/$(MOZ_APP_NAME)
 	sed -e 's/%MAC_APP_NAME%/$(MAC_APP_NAME)/' $(srcdir)/macbuild/Contents/Resources/English.lproj/InfoPlist.strings.in | iconv -f UTF-8 -t UTF-16 > '$(dist_dest)/$(LPROJ)/InfoPlist.strings'
 	rsync -a --exclude-from='$(srcdir)/macbuild/Contents/MacOS-files.in' $(DIST)/bin/ '$(dist_dest)/Contents/Resources'
 	rsync -a --include-from='$(srcdir)/macbuild/Contents/MacOS-files.in' --exclude '*' $(DIST)/bin/ '$(dist_dest)/Contents/MacOS'
+	# MacOS-files-copy.in is a list of files that should be copies rather
+	# than symlinks and placed in .app/Contents/MacOS.
+	rsync -aL --include-from='$(srcdir)/macbuild/Contents/MacOS-files-copy.in' --exclude '*' $(DIST)/bin/ '$(dist_dest)/Contents/MacOS'
 	$(RM) '$(dist_dest)/Contents/MacOS/$(MOZ_APP_NAME)'
 	rsync -aL $(DIST)/bin/$(MOZ_APP_NAME) '$(dist_dest)/Contents/MacOS'
 	cp -RL $(DIST)/branding/firefox.icns '$(dist_dest)/Contents/Resources/firefox.icns'

--- a/basilisk/app/macbuild/Contents/MacOS-files-copy.in
+++ b/basilisk/app/macbuild/Contents/MacOS-files-copy.in
@@ -1,0 +1,11 @@
+# Specifies files that should be copied (via deep copy, resolving symlinks)
+# from dist/bin to the .app/Contents/MacOS directory. Linking is preferred to
+# reduce disk I/O during builds, so just include dylibs which need to be in the
+# same directory as returned by dladdr(3).
+#
+# Some of these dylibs load other dylibs which are assumed to be siblings in
+# the same directory obtained from dladdr(3). With macOS 10.15, dladdr returns
+# absolute resolved paths which breaks this assumption if symlinks are used
+# because the symlink targets are in different directories. Hence the need for
+# them to be copied to the same directory.
+/*.dylib

--- a/basilisk/app/macbuild/Contents/MacOS-files.in
+++ b/basilisk/app/macbuild/Contents/MacOS-files.in
@@ -1,5 +1,4 @@
 /*.app/***
-/*.dylib
 /certutil
 /firefox-bin
 /gtest/***


### PR DESCRIPTION
This should resolve UXP Issue #1469 for local builds on Catalina.

https://drive.google.com/file/d/1jTqBWdmOomLw9uVcVqLVY6BDxC822G2y/view?usp=sharing

Basilisk binary for testing created using this patch. 