### PR TITLE
Add global menubar support for GTK

### DIFF
--- a/basilisk/base/content/browser-menubar.inc
+++ b/basilisk/base/content/browser-menubar.inc
@@ -5,7 +5,11 @@
 
        <menubar id="main-menubar"
                 onpopupshowing="if (event.target.parentNode.parentNode == this &amp;&amp;
+#ifdef MOZ_WIDGET_GTK
+                                    document.documentElement.getAttribute('shellshowingmenubar') != 'true')
+#else
                                     !('@mozilla.org/widget/nativemenuservice;1' in Cc))
+#endif
                                   this.setAttribute('openedwithkey',
                                                     event.target.parentNode.openedWithKey);"
                 style="border:0px;padding:0px;margin:0px;-moz-appearance:none">

--- a/basilisk/base/content/browser.js
+++ b/basilisk/base/content/browser.js
@@ -4691,6 +4691,10 @@ function getTogglableToolbars() {
   let toolbarNodes = Array.slice(gNavToolbox.childNodes);
   toolbarNodes = toolbarNodes.concat(gNavToolbox.externalToolbars);
   toolbarNodes = toolbarNodes.filter(node => node.getAttribute("toolbarname"));
+#ifdef MOZ_WIDGET_GTK
+  if (document.documentElement.getAttribute("shellshowingmenubar") == "true")
+    toolbarNodes = toolbarNodes.filter(node => node.id != "toolbar-menubar");
+#endif
   return toolbarNodes;
 }
 

--- a/basilisk/components/places/content/places.xul
+++ b/basilisk/components/places/content/places.xul
@@ -157,7 +157,11 @@
         <toolbarbutton type="menu" class="tabbable"
               onpopupshowing="document.getElementById('placeContent').focus()"
 #else
+#ifdef MOZ_WIDGET_GTK
+      <menubar id="placesMenu" _moz-menubarkeeplocal="true">
+#else
       <menubar id="placesMenu">
+#endif
         <menu accesskey="&organize.accesskey;" class="menu-iconic"
 #endif
               id="organizeButton" label="&organize.label;"


### PR DESCRIPTION
Tag MoonchildProductions/UXP#1578

This ensures the menubar toggle is not enabled when the global menubar is enabled, and also makes sure the Places toolbar is not exported as that should not be treated as a traditional menubar.